### PR TITLE
Add `register_deprecated` interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build*
 .vscode
+.cache

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This library provides a modern, platform independent, type-safe way of handling 
     - [Range Variables - Code](#range-variables---code)
   - [Option Variables](#option-variables)
     - [Option Variables - Code](#option-variables---code)
+  - [Deprecated Variables](#deprecated-variables)
   - [Prefixless Environment Variables](#prefixless-environment-variables)
     - [Prefixless Environment Variables - Code](#prefixless-environment-variables---code)
 - [Error Handling](#error-handling)
@@ -348,6 +349,20 @@ _Note:_ Options are mostly intended to be used with `enum class` types, but this
 #### Option Variables - Code
 
 For the full code, including the parser for the enum class, see [examples/libenvpp_option_example.cpp](examples/libenvpp_option_example.cpp).
+
+### Deprecated Variables
+
+Sometimes, new releases of your software will deprecate environment variables. To provide users with helpful messages in this case, you can use the 'register_deprecated' feature.
+
+```cpp
+#include <libenvpp/env.hpp>
+
+int main()
+{
+    auto pre = env::prefix("APP");
+    pre.register_deprecated("FEATURE", "The option 'APP_FEATURE' has been deprecated since version x.y. Please use SOMETHING instead.");
+}
+```
 
 ### Prefixless Environment Variables
 

--- a/include/libenvpp/env.hpp
+++ b/include/libenvpp/env.hpp
@@ -330,6 +330,14 @@ class prefix {
 		return registration_option_helper<T, true>(name, options);
 	}
 
+	void register_deprecated(const std::string_view name, const std::string_view deprecation_message)
+	{
+		std::string dm{deprecation_message};
+		m_registered_vars.push_back(detail::variable_data{name, false, [dm](const std::string_view) -> std::any {
+			throw validation_error(dm);
+		}});
+	}
+
 	template <typename T, bool IsRequired, typename U = T>
 	void set_for_testing(const variable_id<T, IsRequired>& var_id, const U& value)
 	{

--- a/test/libenvpp_test.cpp
+++ b/test/libenvpp_test.cpp
@@ -1184,4 +1184,23 @@ TEST_CASE("Errors yield default value with get_or", "[libenvpp][get]")
 	}
 }
 
+TEST_CASE("Deprecated environment variables work as expected", "[libenvpp][deprecated]")
+{
+	auto pre = env::prefix("TEST");
+	pre.register_deprecated("DEPRECATED", "The option 'TEST_DEPRECATED' has been deprecated since v1.0. Use 'TEST_NONDEPRECATED'.");
+
+	SECTION("Nothing happens when not set")
+	{
+		auto parsed = pre.parse_and_validate();
+		CHECK(parsed.ok());
+	}
+
+	SECTION("Deprecation error when set")
+	{
+		auto parsed = pre.parse_and_validate({{"TEST_DEPRECATED","bla"}});
+		CHECK_FALSE(parsed.ok());
+		CHECK_THAT(parsed.error_message(), ContainsSubstring("'TEST_DEPRECATED' has been deprecated"));
+	}
+}
+
 } // namespace env


### PR DESCRIPTION
A small interface addition for a frequent use case in larger projects.