### PR TITLE
[windows] MinGW compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ FetchContent_MakeAvailable(fmt)
 if(LIBENVPP_TESTS)
 	FetchContent_Declare(Catch2
 		GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-		GIT_TAG v3.2.1
+		GIT_TAG v3.7.0
 	)
 	FetchContent_MakeAvailable(Catch2)
 	list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)

--- a/source/libenvpp_environment_windows.cpp
+++ b/source/libenvpp_environment_windows.cpp
@@ -4,7 +4,7 @@
 
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 #include <array>
 


### PR DESCRIPTION
The MinGW Windows.h header is lowercase. This fixes MinGW builds but MSVC builds shouldn't be affected as paths and filenames are not case sensitive on Windows.