### PR TITLE
Introduce an optional, simplified option parsing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,14 +296,13 @@ For the complete code see [examples/libenvpp_range_example.cpp](examples/libenvp
 
 ### Option Variables
 
-Another frequent use-case is that a value is one of a given set of options. For this an environment variable can be registered with `register_[required]_option`, which takes a list of valid options, against which the value is checked. For example:
+Another frequent use-case is that a value is one of a given set of options. For this an environment variable can be registered with `register_[required]_option`, which takes a list of either pairs of strings and corresponding options, or just valid options, against which the value is checked. For example:
 
 ```cpp
 enum class option {
-    first_choice,
-    second_choice,
-    third_choice,
-    default_choice,
+    first,
+    second,
+    fallback,
 };
 
 int main()
@@ -311,29 +310,29 @@ int main()
     auto pre = env::prefix("OPTION");
 
     const auto option_id =
-        pre.register_option<option>("CHOICE", {option::first_choice, option::second_choice, option::third_choice});
+        pre.register_option<option>("CHOICE", {{"first", option::first}, {"second", option::second}});
 
     const auto parsed_and_validated_pre = pre.parse_and_validate();
 
     if (parsed_and_validated_pre.ok()) {
-        const auto opt = parsed_and_validated_pre.get_or(option_id, option::default_choice);
+        const auto opt = parsed_and_validated_pre.get_or(option_id, option::fallback);
     }
 }
 ```
 
-This registers an `enum class` option, where only a subset of all possible values is considered valid, so that `option::default_choice` can be used as the value if the variable is not set.
+This registers an `enum class` option, where only a subset of all possible values is considered valid, so that `option::fallback` can be used as the value if the variable is not set.
 
 _Note:_ The list of options provided when registering must not be empty, and must not contain duplicates.
 
 _Note:_ As with range variables, the default value given with `get_or` is not enforced to be within the list of options given when registering the option variable.
 
-_Note:_ Since C++ does not provide any way to automatically parse `enum class` types from string, the example above additionally requires a specialized `default_parser` for the `enum class` type.
+_Note:_ For the variant where no mapping to strings is provided, a specialized `default_parser` for the `enum class` type must exist.
 
 _Note:_ Options are mostly intended to be used with `enum class` types, but this is in no way a requirement. Any type can be used as an option, and `enum class` types can also just be normal environment variables.
 
 #### Option Variables - Code
 
-For the full code, including the parser for the enum class, see [examples/libenvpp_option_example.cpp](examples/libenvpp_option_example.cpp).
+For the full code, which features both the simple case shown above and a case with a custom parser, see [examples/libenvpp_option_example.cpp](examples/libenvpp_option_example.cpp).
 
 ### Deprecated Variables
 

--- a/examples/libenvpp_option_example.cpp
+++ b/examples/libenvpp_option_example.cpp
@@ -36,12 +36,21 @@ struct default_parser<option> {
 };
 } // namespace env
 
+enum class simple_option {
+	opt_a,
+	opt_b,
+	opt_c,
+};
+
 int main()
 {
 	auto pre = env::prefix("OPTION");
 
 	const auto option_id =
 	    pre.register_option<option>("CHOICE", {option::first_choice, option::second_choice, option::third_choice});
+
+	const auto simple_option_id = pre.register_option<simple_option>(
+	    "SIMPLE", {{"opt_a", simple_option::opt_a}, {"opt_b", simple_option::opt_b}, {"opt_c", simple_option::opt_c}});
 
 	const auto parsed_and_validated_pre = pre.parse_and_validate();
 
@@ -61,6 +70,21 @@ int main()
 			break;
 		case option::default_choice:
 			std::cout << "default_choice" << std::endl;
+			break;
+		}
+
+		const auto simple_opt = parsed_and_validated_pre.get_or(simple_option_id, simple_option::opt_a);
+
+		std::cout << "Simple option: ";
+		switch (simple_opt) {
+		case simple_option::opt_a:
+			std::cout << "opt_a" << std::endl;
+			break;
+		case simple_option::opt_b:
+			std::cout << "opt_b" << std::endl;
+			break;
+		case simple_option::opt_c:
+			std::cout << "opt_c" << std::endl;
 			break;
 		}
 	} else {


### PR DESCRIPTION
This makes the very common case of just parsing one of a set of options simpler.