### PR TITLE
parser.hpp: make compatible with modules

### DIFF
--- a/include/libenvpp/detail/parser.hpp
+++ b/include/libenvpp/detail/parser.hpp
@@ -55,7 +55,7 @@ inline constexpr auto is_stringstream_constructible_v = is_stringstream_construc
 
 //////////////////////////////////////////////////////////////////////////
 
-[[nodiscard]] static inline bool parse_bool(const std::string_view str)
+[[nodiscard]] inline bool parse_bool(const std::string_view str)
 {
 	constexpr auto to_lower_char = [](const char c) -> char {
 		if ('A' <= c && c <= 'Z') {


### PR DESCRIPTION
`parse_bool` is referenced from `env::variable_id` via some other types. If I now have
```c++
module;
#include <libenvpp/env.hpp>
export module testModule;
export
{
    template <typename VarType, bool Required>
    struct EnvironmentVariableBase
    {
env::variable_id<VarType, Required> m_id;
    }
}
```
I export a type that references a TU local definition in its template instantiation, which is invalid c++ and causes gcc to crash (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=125356). inline is enough here and also prevents binary bloat since only one definition is created for every TU that includes `env.hpp`.