### PR TITLE
Fix compatibility with fmt 12.2.0

### DIFF
--- a/cmake_integration_test/common/test_app.cpp
+++ b/cmake_integration_test/common/test_app.cpp
@@ -1,6 +1,6 @@
 #include <libenvpp/env.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 int main()
 {

--- a/include/libenvpp/detail/check.hpp
+++ b/include/libenvpp/detail/check.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <string_view>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #ifndef LIBENVPP_STRINGIFY
 #define LIBENVPP_STRINGIFY_HELPER(expression) #expression

--- a/include/libenvpp/detail/parser.hpp
+++ b/include/libenvpp/detail/parser.hpp
@@ -10,7 +10,7 @@
 #include <type_traits>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libenvpp/detail/errors.hpp>
 #include <libenvpp/detail/expected.hpp>

--- a/include/libenvpp/env.hpp
+++ b/include/libenvpp/env.hpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <libenvpp/detail/edit_distance.hpp>

--- a/source/libenvpp_errors.cpp
+++ b/source/libenvpp_errors.cpp
@@ -1,6 +1,6 @@
 #include <libenvpp/detail/errors.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libenvpp/detail/environment.hpp>
 

--- a/source/libenvpp_testing.cpp
+++ b/source/libenvpp_testing.cpp
@@ -1,6 +1,6 @@
 #include <libenvpp/detail/testing.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libenvpp/detail/errors.hpp>
 

--- a/test/libenvpp_parser_test.cpp
+++ b/test/libenvpp_parser_test.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libenvpp/detail/parser.hpp>
 

--- a/test/libenvpp_test.cpp
+++ b/test/libenvpp_test.cpp
@@ -5,7 +5,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libenvpp/detail/environment.hpp>
 #include <libenvpp/env.hpp>

--- a/test/libenvpp_testing_test.cpp
+++ b/test/libenvpp_testing_test.cpp
@@ -5,7 +5,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <libenvpp/detail/environment.hpp>
 #include <libenvpp/env.hpp>


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.